### PR TITLE
Update offscreen.js

### DIFF
--- a/offscreen.js
+++ b/offscreen.js
@@ -74,23 +74,9 @@ function playAudioUrl(audioUrl) {
       
       // Connect to audio context only once
       if (!hasSourceConnected) {
-        try {
-          // Disconnect previous source if it exists
-          if (audioSource) {
-            try {
-              audioSource.disconnect();
-            } catch (e) {
-              // Ignore errors if already disconnected
-            }
-          }
-          
-          // Create and connect new source
-          audioSource = audioContext.createMediaElementSource(audioElement);
-          audioSource.connect(audioContext.destination);
-          hasSourceConnected = true;
-        } catch (e) {
-          console.error('Error connecting audio source:', e);
-        }
+        audioSource = audioContext.createMediaElementSource(audioElement);
+        audioSource.connect(audioContext.destination);
+        hasSourceConnected = true;
       }
       
       chrome.runtime.sendMessage({ type: 'stateUpdate', state: 'playing' });


### PR DESCRIPTION
I got an error in trying to do TTS multiple time in short period of time, I discovered that a single <audio> element can only be wrapped by createMediaElementSource() once per AudioContext. If you try to call it again for the same element in the same context, you’ll get the "media element source already connected" error.

Instead of re-creating the media source for each play, only create it once.

I'm not 100% confident that this is the way to go since I don't work with JS or chrome extensions but it seems to work for me on Edge.